### PR TITLE
Replace CUDA Runtime API with Driver API

### DIFF
--- a/include/nccl_ofi_cuda.h
+++ b/include/nccl_ofi_cuda.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-#include <cuda_runtime.h>
+#include <cuda.h>
 
 int nccl_net_ofi_cuda_init(void);
 
@@ -27,18 +27,18 @@ int nccl_net_ofi_cuda_init(void);
  */
 int nccl_net_ofi_get_cuda_device(void *data, int *dev_id);
 
-extern cudaError_t (*nccl_net_ofi_cudaRuntimeGetVersion)(int *runtimeVersion);
+extern CUresult (*nccl_net_ofi_cuDriverGetVersion)(int *driverVersion);
 
-extern cudaError_t (*nccl_net_ofi_cudaPointerGetAttributes)(struct cudaPointerAttributes* attributes, const void* ptr);
+extern CUresult (*nccl_net_ofi_cuPointerGetAttribute)(void *data, CUpointer_attribute attribute, CUdeviceptr ptr);
 
-extern cudaError_t (*nccl_net_ofi_cudaGetDevice)(int* device);
-extern cudaError_t (*nccl_net_ofi_cudaGetDeviceCount)(int* count);
+extern CUresult (*nccl_net_ofi_cuCtxGetDevice)(CUdevice *device);
+extern CUresult (*nccl_net_ofi_cuDeviceGetCount)(int* count);
 
-#if CUDART_VERSION >= 11030
-extern cudaError_t (*nccl_net_ofi_cudaDeviceFlushGPUDirectRDMAWrites)(enum cudaFlushGPUDirectRDMAWritesTarget target,
-								      enum cudaFlushGPUDirectRDMAWritesScope scope);
+#if CUDA_VERSION >= 11030
+extern CUresult (*nccl_net_ofi_cuFlushGPUDirectRDMAWrites)(CUflushGPUDirectRDMAWritesTarget target,
+							   CUflushGPUDirectRDMAWritesScope scope);
 #else
-extern void *nccl_net_ofi_cudaDeviceFlushGPUDirectRDMAWrites;
+extern void *nccl_net_ofi_cuFlushGPUDirectRDMAWrites;
 #endif
 
 #ifdef _cplusplus

--- a/m4/check_pkg_cuda.m4
+++ b/m4/check_pkg_cuda.m4
@@ -29,10 +29,10 @@ AC_DEFUN([CHECK_PKG_CUDA], [
          LDFLAGS="${CUDA_LDFLAGS} ${LDFLAGS}"])
 
   AS_IF([test "${check_pkg_found}" = "yes"],
-        [AC_CHECK_HEADERS([cuda_runtime.h], [], [check_pkg_found=no])])
+        [AC_CHECK_HEADERS([cuda.h], [], [check_pkg_found=no])])
 
   AS_IF([test "${check_pkg_found}" = "yes"],
-        [AC_SEARCH_LIBS([cudaHostAlloc], [cudart], [CUDA_LIBS="-lcudart"], [check_pkg_found=no])])
+        [AC_SEARCH_LIBS([cuMemHostAlloc], [cuda], [CUDA_LIBS="-lcuda"], [check_pkg_found=no])])
 
   AS_IF([test "${check_pkg_found}" = "yes"],
         [check_pkg_define=1

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -846,16 +846,16 @@ int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t **plugin_p)
 	}
 
 	int cuda_version;
-	if (nccl_net_ofi_cudaRuntimeGetVersion(&cuda_version) != cudaSuccess) {
-		NCCL_OFI_WARN("cudaRuntimeGetVersion failed");
+	if (nccl_net_ofi_cuDriverGetVersion(&cuda_version) != CUDA_SUCCESS) {
+		NCCL_OFI_WARN("cuDriverGetVersion failed");
 		ret = -ENOTSUP;
 		goto exit;
 	}
 
-	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Using CUDA runtime version %d", cuda_version);
+	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Using CUDA driver version %d", cuda_version);
 	if (ofi_nccl_cuda_flush_enable()) {
-		if (nccl_net_ofi_cudaDeviceFlushGPUDirectRDMAWrites == NULL) {
-			NCCL_OFI_WARN("CUDA flush requested, but cudaDeviceFlushGPUDIrectRDMAWrite not found.");
+		if (nccl_net_ofi_cuFlushGPUDirectRDMAWrites == NULL) {
+			NCCL_OFI_WARN("CUDA flush requested, but cuFlushGPUDirectRDMAWrites not found.");
 			cuda_flush = false;
 		} else {
 			NCCL_OFI_WARN("CUDA flush enabled");
@@ -1013,7 +1013,7 @@ int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t **plugin_p)
 		int num_accelerators = ofi_ndevices;
 
 #if HAVE_CUDA
-		if (nccl_net_ofi_cudaGetDeviceCount(&num_accelerators) != cudaSuccess) {
+		if (nccl_net_ofi_cuDeviceGetCount(&num_accelerators) != CUDA_SUCCESS) {
 			NCCL_OFI_WARN("Error getting CUDA device count");
 			ret = -ENOTSUP;
 			goto exit;
@@ -1265,13 +1265,13 @@ int nccl_net_ofi_info_properties(struct fi_info *nic_prov, int dev_id, int num_d
 		int num_gpus_visible, active_cuda_device, gpus_per_conn;
 		size_t c;
 
-		if (nccl_net_ofi_cudaGetDeviceCount(&num_gpus_visible) != cudaSuccess) {
+		if (nccl_net_ofi_cuDeviceGetCount(&num_gpus_visible) != CUDA_SUCCESS) {
 			NCCL_OFI_WARN("Error getting CUDA device count");
 			ret = -ENOTSUP;
 			goto error;
 		}
 
-		if (nccl_net_ofi_cudaGetDevice(&active_cuda_device) != cudaSuccess) {
+		if (nccl_net_ofi_cuCtxGetDevice(&active_cuda_device) != CUDA_SUCCESS) {
 			NCCL_OFI_WARN("Error getting current CUDA device");
 			ret = -ENOTSUP;
 			goto error;

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -3410,13 +3410,13 @@ static int flush(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 	if (ofi_nccl_gdr_flush_disable() || support_gdr == GDR_UNSUPPORTED)
 		goto exit;
 
-#if CUDART_VERSION >= 11030
+#if CUDA_VERSION >= 11030
 	if (cuda_flush) {
-		cudaError_t cuda_ret = nccl_net_ofi_cudaDeviceFlushGPUDirectRDMAWrites(
-			cudaFlushGPUDirectRDMAWritesTargetCurrentDevice,
-			cudaFlushGPUDirectRDMAWritesToOwner);
+		CUresult cuda_ret = nccl_net_ofi_cuFlushGPUDirectRDMAWrites(
+			CU_FLUSH_GPU_DIRECT_RDMA_WRITES_TARGET_CURRENT_CTX,
+			CU_FLUSH_GPU_DIRECT_RDMA_WRITES_TO_OWNER);
 
-		if (cuda_ret != cudaSuccess) {
+		if (cuda_ret != CUDA_SUCCESS) {
 			ret = ncclUnhandledCudaError;
 			NCCL_OFI_WARN("Error performing CUDA GDR flush");
 			goto exit;

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -949,13 +949,13 @@ static int flush(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 	if (ofi_nccl_gdr_flush_disable() || support_gdr == GDR_UNSUPPORTED)
 		goto exit;
 
-#if CUDART_VERSION >= 11030
+#if CUDA_VERSION >= 11030
 	if (cuda_flush) {
-		cudaError_t cuda_ret = nccl_net_ofi_cudaDeviceFlushGPUDirectRDMAWrites(
-			cudaFlushGPUDirectRDMAWritesTargetCurrentDevice,
-			cudaFlushGPUDirectRDMAWritesToOwner);
+		CUresult cuda_ret = nccl_net_ofi_cuFlushGPUDirectRDMAWrites(
+			CU_FLUSH_GPU_DIRECT_RDMA_WRITES_TARGET_CURRENT_CTX,
+			CU_FLUSH_GPU_DIRECT_RDMA_WRITES_TO_OWNER);
 
-		if (cuda_ret != cudaSuccess) {
+		if (cuda_ret != CUDA_SUCCESS) {
 			ret = ncclUnhandledCudaError;
 			NCCL_OFI_WARN("Error performing CUDA GDR flush");
 			goto exit;

--- a/tests/functional/nccl_message_transfer.c
+++ b/tests/functional/nccl_message_transfer.c
@@ -75,7 +75,11 @@ int main(int argc, char* argv[])
 	/* Set CUDA device for subsequent device memory allocation, in case GDR is used */
 	cuda_dev = local_rank;
 	NCCL_OFI_TRACE(NCCL_NET, "Using CUDA device %d for memory allocation", cuda_dev);
-	CUDACHECK(cudaSetDevice(cuda_dev));
+
+	CUDACHECK(cuInit(0));
+	CUcontext context;
+	CUDACHECK(cuCtxCreate(&context, CU_CTX_SCHED_SPIN|CU_CTX_MAP_HOST, cuda_dev));
+	CUDACHECK(cuCtxSetCurrent(context));
 
 	/* Get external Network from NCCL-OFI library */
 	extNet = get_extNet();

--- a/tests/functional/ring.c
+++ b/tests/functional/ring.c
@@ -78,8 +78,11 @@ int main(int argc, char *argv[])
 	/* Set CUDA device for subsequent device memory allocation, in case GDR is used */
 	cuda_dev = local_rank;
 	NCCL_OFI_TRACE(NCCL_NET, "Using CUDA device %d for memory allocation", cuda_dev);
-	CUDACHECK(cudaSetDevice(cuda_dev));
 
+	CUDACHECK(cuInit(0));
+	CUcontext context;
+	CUDACHECK(cuCtxCreate(&context, CU_CTX_SCHED_SPIN|CU_CTX_MAP_HOST, cuda_dev));
+	CUDACHECK(cuCtxSetCurrent(context));
 	/*
 	 * Calculate the rank of the next process in the ring.  Use the
 	 * modulus operator so that the last process "wraps around" to

--- a/tests/functional/test-common.h
+++ b/tests/functional/test-common.h
@@ -17,7 +17,7 @@
 #include <unistd.h>
 #include <dlfcn.h>
 #include <stdarg.h>
-#include <cuda_runtime.h>
+#include <cuda.h>
 
 #define STR2(v)		#v
 #define STR(v)		STR2(v)
@@ -35,9 +35,11 @@
 } while (false);
 
 #define CUDACHECK(call) do {							\
-        cudaError_t e = call;							\
-        if (e != cudaSuccess) {							\
-                NCCL_OFI_WARN("Cuda failure '%s'", cudaGetErrorString(e));	\
+        CUresult e = call;							\
+        if (e != CUDA_SUCCESS) {						\
+                const char *error_str;						\
+                cuGetErrorString(e, &error_str);				\
+                NCCL_OFI_WARN("Cuda failure '%s'", error_str);			\
                 return ncclUnhandledCudaError;					\
         }									\
 } while(false);
@@ -102,11 +104,11 @@ ncclResult_t allocate_buff(void **buf, size_t size, int buffer_type)
 	switch (buffer_type) {
 	case NCCL_PTR_CUDA:
 		NCCL_OFI_TRACE(NCCL_NET, "Allocating CUDA buffer");
-		CUDACHECK(cudaMalloc(buf, size));
+		CUDACHECK(cuMemAlloc((CUdeviceptr *) buf, size));
 		break;
 	case NCCL_PTR_HOST:
 		NCCL_OFI_TRACE(NCCL_NET, "Allocating host buffer");
-		CUDACHECK(cudaHostAlloc((void **)buf, size, cudaHostAllocMapped));
+		CUDACHECK(cuMemHostAlloc(buf, size, CU_MEMHOSTALLOC_DEVICEMAP));
 		break;
 	default:
 		NCCL_OFI_WARN("Unidentified buffer type: %d", buffer_type);
@@ -120,7 +122,7 @@ ncclResult_t initialize_buff(void *buf, size_t size, int buffer_type)
 {
 	switch (buffer_type) {
 	case NCCL_PTR_CUDA:
-		CUDACHECK(cudaMemset(buf, '1', size));
+		CUDACHECK(cuMemsetD8((CUdeviceptr) buf, '1', size));
 		break;
 	case NCCL_PTR_HOST:
 		memset(buf, '1', size);
@@ -137,10 +139,10 @@ ncclResult_t deallocate_buffer(void *buf, int buffer_type)
 {
 	switch (buffer_type) {
 	case NCCL_PTR_CUDA:
-		CUDACHECK(cudaFree((void *)buf));
+		CUDACHECK(cuMemFree((CUdeviceptr) buf));
 		break;
 	case NCCL_PTR_HOST:
-		CUDACHECK(cudaFreeHost((void *)buf));
+		CUDACHECK(cuMemFreeHost((void *)buf));
 		break;
 	default:
 		NCCL_OFI_WARN("Unidentified buffer type: %d", buffer_type);
@@ -158,7 +160,7 @@ ncclResult_t validate_data(char *recv_buf, char *expected_buf, size_t size, int 
 	switch (buffer_type) {
 	case NCCL_PTR_CUDA:
 		OFINCCLCHECK(allocate_buff((void **)&recv_buf_host, size, NCCL_PTR_HOST));
-		CUDACHECK(cudaMemcpy(recv_buf_host, recv_buf, size, cudaMemcpyDeviceToHost));
+		CUDACHECK(cuMemcpyDtoH(recv_buf_host, (CUdeviceptr) recv_buf, size));
 
 		ret = memcmp(recv_buf_host, expected_buf, size);
 		if (ret != 0) {


### PR DESCRIPTION
Links the CUDA Driver library ("libcuda.so") to the OFI NCCL plugin instead of the CUDA Runtime library ("libcudart.so"), and replaces all CUDA Runtime API calls with their functional equivalents in the CUDA Driver API.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
