### PR TITLE
Prototype Libfabric resource unique_ptr wrappers

### DIFF
--- a/include/cm/nccl_ofi_cm_resources.h
+++ b/include/cm/nccl_ofi_cm_resources.h
@@ -15,6 +15,7 @@
 #include "cm/nccl_ofi_cm_reqs.h"
 
 #include "nccl_ofi_freelist.h"
+#include "nccl_ofi_ofiwrapper.h"
 
 namespace nccl_ofi_cm {
 
@@ -78,7 +79,7 @@ public:
 	/**
 	 * Close associated ofi_ep, while leaving other resources open
 	 */
-	int close_ofi_ep();
+	void close_ofi_ep();
 
 	/* Menory registration/deregistration. Note: these functions are static
 	   to be usable with the freelist interface */
@@ -91,8 +92,8 @@ private:
 	nccl_ofi_idpool_t &mr_key_pool;
 
 	/* Created by CM */
-	fid_ep *ofi_ep;
-	fid_av *av;
+	FidEpPtr ofi_ep;
+	FidAvPtr av;
 };
 
 /**

--- a/include/nccl_ofi_ofiutils.h
+++ b/include/nccl_ofi_ofiutils.h
@@ -8,6 +8,7 @@
 #include <rdma/fabric.h>
 
 #include "nccl_ofi_param.h"
+#include "nccl_ofi_ofiwrapper.h"
 
 int nccl_ofi_ofiutils_get_providers(const char *prov_include,
 				    uint32_t required_version,
@@ -19,19 +20,21 @@ int nccl_ofi_ofiutils_get_providers(const char *prov_include,
 /*
  * @brief	Allocates and initialises libfabric endpoint and AV.
  *
- * @param cq:	Completion queue to which the new endpoint will be bound
- * @return	Endpoint ep
- * @return	Address vector av
+ * @param info:		Fabric info for endpoint creation
+ * @param domain:	Fabric domain
+ * @param ep:		Output smart pointer for endpoint
+ * @param av:		Output smart pointer for address vector
+ * @param cq:		Completion queue to which the new endpoint will be bound
+ * @return		0 on success, negative error code on failure
  */
 int nccl_ofi_ofiutils_init_connection(struct fi_info *info, struct fid_domain *domain,
-				      struct fid_ep **ep,   struct fid_av **av,
+				      FidEpPtr& ep, FidAvPtr& av,
 				      struct fid_cq *cq);
 
 /*
  * @brief	Release libfabric endpoint and address vector
  */
-void nccl_ofi_ofiutils_ep_release(struct fid_ep *ep, struct fid_av *av,
-				  int dev_id);
+void nccl_ofi_ofiutils_ep_release(FidEpPtr& ep, FidAvPtr& av, int dev_id);
 
 /*
  * @brief	Free libfabric NIC info list.

--- a/include/nccl_ofi_ofiwrapper.h
+++ b/include/nccl_ofi_ofiwrapper.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#ifndef NCCL_OFI_OFIWRAPPER_H_
+#define NCCL_OFI_OFIWRAPPER_H_
+
+#include <memory>
+#include <rdma/fabric.h>
+#include "nccl_ofi_log.h"
+
+/**
+ * @brief Custom deleter for fid_ep resources
+ * 
+ * Provides proper cleanup of libfabric endpoint resources with
+ * appropriate error logging.
+ */
+struct FidEpDeleter {
+    void operator()(struct fid_ep* ep) const {
+        if (ep) {
+            int ret = fi_close(&ep->fid);
+            if (ret != 0) {
+                NCCL_OFI_WARN("Failed to close fid_ep: %s", fi_strerror(-ret));
+            }
+        }
+    }
+};
+
+/**
+ * @brief Custom deleter for fid_av resources
+ * 
+ * Provides proper cleanup of libfabric address vector resources with
+ * appropriate error logging.
+ */
+struct FidAvDeleter {
+    void operator()(struct fid_av* av) const {
+        if (av) {
+            int ret = fi_close(&av->fid);
+            if (ret != 0) {
+                NCCL_OFI_WARN("Failed to close fid_av: %s", fi_strerror(-ret));
+            }
+        }
+    }
+};
+
+/**
+ * Type aliases for cleaner code and easier maintenance
+ */
+using FidEpPtr = std::unique_ptr<struct fid_ep, FidEpDeleter>;
+using FidAvPtr = std::unique_ptr<struct fid_av, FidAvDeleter>;
+
+/**
+ * @brief Factory function for creating fid_ep smart pointers
+ * 
+ * @param ep     Raw fid_ep pointer to wrap
+ * @return       Smart pointer with proper deleter
+ */
+inline FidEpPtr make_fid_ep_ptr(struct fid_ep* ep) {
+    return FidEpPtr(ep);
+}
+
+/**
+ * @brief Factory function for creating fid_av smart pointers
+ * 
+ * @param av     Raw fid_av pointer to wrap
+ * @return       Smart pointer with proper deleter
+ */
+inline FidAvPtr make_fid_av_ptr(struct fid_av* av) {
+    return FidAvPtr(av);
+}
+
+#endif // NCCL_OFI_OFIWRAPPER_H_

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -18,6 +18,7 @@
 #include "nccl_ofi_log.h"
 #include "nccl_ofi_msgbuff.h"
 #include "nccl_ofi_scheduler.h"
+#include "nccl_ofi_ofiwrapper.h"
 #include "nccl_ofi_topo.h"
 #if HAVE_NVTX_TRACING
 #include <nvtx3/nvToolsExt.h>
@@ -829,10 +830,21 @@ protected:
  * specific rail.
  */
 struct nccl_net_ofi_ep_rail {
+	/* Default constructor */
+	nccl_net_ofi_ep_rail() = default;
+	
+	/* Move constructor and assignment */
+	nccl_net_ofi_ep_rail(nccl_net_ofi_ep_rail&&) = default;
+	nccl_net_ofi_ep_rail& operator=(nccl_net_ofi_ep_rail&&) = default;
+	
+	/* Delete copy operations since smart pointers are non-copyable */
+	nccl_net_ofi_ep_rail(const nccl_net_ofi_ep_rail&) = delete;
+	nccl_net_ofi_ep_rail& operator=(const nccl_net_ofi_ep_rail&) = delete;
+
 	uint16_t rail_id;
 
 	/* Local libfabric endpoint handle */
-	struct fid_ep *ofi_ep;
+	FidEpPtr ofi_ep;
 
 	/* Name of local libfabric endpoint */
 	char local_ep_name[MAX_EP_ADDR];
@@ -841,7 +853,7 @@ struct nccl_net_ofi_ep_rail {
 	size_t local_ep_name_len;
 
 	/* Address vector handle */
-	struct fid_av *av;
+	FidAvPtr av;
 
 	/*
 	 * Rx buffer management

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -11,6 +11,7 @@
 #include "nccl_ofi.h"
 #include "nccl_ofi_freelist.h"
 #include "nccl_ofi_log.h"
+#include "nccl_ofi_ofiwrapper.h"
 
 /* This is the initial value of mr_key. At key deregisteration time,
  * it is used to validate if a key was generated and needed to be freed or not.
@@ -234,10 +235,10 @@ public:
 	uint64_t max_tag;
 
 	/* Endpoint handle to communicate to */
-	struct fid_ep *ofi_ep = nullptr;
+	FidEpPtr ofi_ep;
 
 	/* Address vector handle */
-	struct fid_av *av = nullptr;
+	FidAvPtr av;
 
 protected:
 	/**

--- a/src/cm/nccl_ofi_cm_resources.cpp
+++ b/src/cm/nccl_ofi_cm_resources.cpp
@@ -12,7 +12,7 @@ endpoint::endpoint(nccl_net_ofi_domain_t &domain) :
 {
 	fi_info *info = domain.get_device()->get_ofi_info_for_cm();
 	fid_cq *cq = domain.get_ofi_cq_for_cm();
-	int ret = nccl_ofi_ofiutils_init_connection(info, ofi_domain, &this->ofi_ep, &this->av, cq);
+	int ret = nccl_ofi_ofiutils_init_connection(info, ofi_domain, this->ofi_ep, this->av, cq);
 	if (ret != 0) {
 		/* We can't return an error. If not caught, this is going to propagate up and
 		 * eventually terminate the program, which may or may not be what we want.
@@ -31,7 +31,7 @@ endpoint::~endpoint()
 
 int endpoint::get_ep_address(void *address, size_t &addr_len)
 {
-	int ret = fi_getname(&ofi_ep->fid, address, &addr_len);
+	int ret = fi_getname(&ofi_ep.get()->fid, address, &addr_len);
 	if (ret == -FI_ETOOSMALL) {
 		NCCL_OFI_WARN("Endpoint's address length (%zu) is larger than supplied buffer length",
 			      addr_len);
@@ -47,7 +47,7 @@ int endpoint::get_ep_address(void *address, size_t &addr_len)
 fi_addr_t endpoint::av_insert_address(const void *address)
 {
 	fi_addr_t ret_addr;
-	int ret = fi_av_insert(av, address, 1, &ret_addr, 0, NULL);
+	int ret = fi_av_insert(av.get(), address, 1, &ret_addr, 0, NULL);
 	if (OFI_UNLIKELY(ret != 1)) {
 		NCCL_OFI_WARN("CM: Unable to insert remote address into address vector "
 			      "for device.");
@@ -151,10 +151,7 @@ cm_resources::~cm_resources()
 	   The endpoint must be closed first, since posted buffers and requests cannot
 	   be freed until the endpoint is closed.
 	 */
-	int ret = ep.close_ofi_ep();
-	if (ret != 0) {
-		NCCL_OFI_WARN("Failed to close OFI endpoint: %d", ret);
-	}
+	ep.close_ofi_ep();
 
 	/* Free all requests. (A unique_ptr would be better here so these can be freed
 	   automatically) */
@@ -232,7 +229,7 @@ int endpoint::reg_mr(void *ep_ptr, void *data, size_t size, void **mr_handle)
 	}
 
 	if (endpoint_mr) {
-		ret = fi_mr_bind(ret_handle->mr, &ep->ofi_ep->fid, 0);
+		ret = fi_mr_bind(ret_handle->mr, &ep->ofi_ep.get()->fid, 0);
 		if (OFI_UNLIKELY(ret != 0)) {
 			NCCL_OFI_WARN("CM: Unable to bind MR to EP. RC: %d, Error: %s",
 				      ret, fi_strerror(-ret));
@@ -263,7 +260,7 @@ int endpoint::send(nccl_ofi_cm_conn_msg &conn_msg, size_t size, mr_handle_t mr_h
 {
 	void *desc = fi_mr_desc(mr_handle.mr);
 
-	ssize_t ret = fi_send(ofi_ep, &conn_msg, size, desc,
+	ssize_t ret = fi_send(ofi_ep.get(), &conn_msg, size, desc,
 			      dest_addr, &req.ctx.ofi_ctx);
 	if (ret != 0 && ret != -FI_EAGAIN) {
 		NCCL_OFI_WARN("Error in call to fi_send. RC: %zd, Error: %s",
@@ -279,7 +276,7 @@ int endpoint::recv(nccl_ofi_cm_conn_msg &conn_msg, size_t size, mr_handle_t mr_h
 {
 	void *desc = fi_mr_desc(mr_handle.mr);
 
-	ssize_t ret = fi_recv(ofi_ep, &conn_msg, size, desc,
+	ssize_t ret = fi_recv(ofi_ep.get(), &conn_msg, size, desc,
 			      FI_ADDR_UNSPEC, &req.ctx.ofi_ctx);
 	if (ret != 0 && ret != -FI_EAGAIN) {
 		NCCL_OFI_WARN("Error posting rx buffer. RC: %zd, Error: %s",
@@ -291,14 +288,11 @@ int endpoint::recv(nccl_ofi_cm_conn_msg &conn_msg, size_t size, mr_handle_t mr_h
 }
 
 
-int endpoint::close_ofi_ep()
+void endpoint::close_ofi_ep()
 {
-	if (ofi_ep == nullptr) {
+	if (ofi_ep.get() == nullptr) {
 		NCCL_OFI_WARN("ep was already closed");
-		return -EINVAL;
+		return;
 	}
-
-	int ret = fi_close(&ofi_ep->fid);
-	ofi_ep = nullptr;
-	return ret;
+	ofi_ep.reset();
 }

--- a/src/nccl_ofi_ofiutils.cpp
+++ b/src/nccl_ofi_ofiutils.cpp
@@ -220,13 +220,16 @@ int nccl_ofi_ofiutils_get_providers(const char *prov_include,
 
 
 int nccl_ofi_ofiutils_init_connection(struct fi_info *info, struct fid_domain *domain,
-				      struct fid_ep **ep, struct fid_av **av, struct fid_cq *cq)
+				      FidEpPtr& ep, FidAvPtr& av,
+				      struct fid_cq *cq)
 {
 	int ret = 0;
 	struct fi_av_attr av_attr = {};
+	struct fid_ep *raw_ep = nullptr;
+	struct fid_av *raw_av = nullptr;
 
 	/* Create transport level communication endpoint(s) */
-	ret = fi_endpoint(domain, info, ep, NULL);
+	ret = fi_endpoint(domain, info, &raw_ep, NULL);
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Couldn't allocate endpoint. RC: %d, ERROR: %s",
 			      ret, fi_strerror(-ret));
@@ -234,7 +237,7 @@ int nccl_ofi_ofiutils_init_connection(struct fi_info *info, struct fid_domain *d
 	}
 
 	/* Open AV */
-	ret = fi_av_open(domain, &av_attr, av, NULL);
+	ret = fi_av_open(domain, &av_attr, &raw_av, NULL);
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Couldn't open AV. RC: %d, ERROR: %s",
 			      ret, fi_strerror(-ret));
@@ -242,7 +245,7 @@ int nccl_ofi_ofiutils_init_connection(struct fi_info *info, struct fid_domain *d
 	}
 
 	/* Bind CQ to endpoint */
-	ret = fi_ep_bind(*ep, &(cq->fid), FI_TRANSMIT | FI_RECV);
+	ret = fi_ep_bind(raw_ep, &(cq->fid), FI_TRANSMIT | FI_RECV);
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Couldn't bind EP-CQ. RC: %d, ERROR: %s",
 			      ret, fi_strerror(-ret));
@@ -250,7 +253,7 @@ int nccl_ofi_ofiutils_init_connection(struct fi_info *info, struct fid_domain *d
 	}
 
 	/* Bind AV to endpoint */
-	ret = fi_ep_bind(*ep, &((*av)->fid), 0);
+	ret = fi_ep_bind(raw_ep, &(raw_av->fid), 0);
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Couldn't bind EP-AV. RC: %d, ERROR: %s",
 			      ret, fi_strerror(-ret));
@@ -275,7 +278,7 @@ int nccl_ofi_ofiutils_init_connection(struct fi_info *info, struct fid_domain *d
 #if HAVE_DECL_FI_OPT_SHARED_MEMORY_PERMITTED
 	{
 		bool optval = false;
-		ret = fi_setopt(&(*ep)->fid, FI_OPT_ENDPOINT,
+		ret = fi_setopt(&raw_ep->fid, FI_OPT_ENDPOINT,
 				FI_OPT_SHARED_MEMORY_PERMITTED, &optval,
 				sizeof(optval));
 		if (ret == -FI_EOPNOTSUPP || ret == -FI_ENOPROTOOPT) {
@@ -309,7 +312,7 @@ int nccl_ofi_ofiutils_init_connection(struct fi_info *info, struct fid_domain *d
 			  FI_VERSION(1, 18)) && support_gdr != GDR_UNSUPPORTED) {
 #if (HAVE_CUDA && HAVE_DECL_FI_OPT_CUDA_API_PERMITTED)
 		bool optval = false;
-		ret = fi_setopt(&(*ep)->fid, FI_OPT_ENDPOINT,
+		ret = fi_setopt(&raw_ep->fid, FI_OPT_ENDPOINT,
 				FI_OPT_CUDA_API_PERMITTED, &optval,
 				sizeof(optval));
 		if (ret == -FI_EOPNOTSUPP || ret == -FI_ENOPROTOOPT) {
@@ -355,29 +358,35 @@ int nccl_ofi_ofiutils_init_connection(struct fi_info *info, struct fid_domain *d
 	}
 	/* Run platform-specific endpoint configuration hook if declared */
 	if (platform_config_endpoint) {
-		ret = platform_config_endpoint(info, *ep);
+		ret = platform_config_endpoint(info, raw_ep);
 		if (ret != 0)
 			goto error;
 	}
 
 	/* Enable endpoint for communication */
-	ret = fi_enable(*ep);
+	ret = fi_enable(raw_ep);
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Couldn't enable endpoint. RC: %d, ERROR: %s",
 			      ret, fi_strerror(-ret));
 		goto error;
 	}
 
+	/* Create smart pointers - this transfers ownership */
+	ep = make_fid_ep_ptr(raw_ep);
+	av = make_fid_av_ptr(raw_av);
+	
+	/* Clear raw pointers since ownership is transferred */
+	raw_ep = nullptr;
+	raw_av = nullptr;
+
 	return ret;
  error:
-	if (*ep) {
-		fi_close((fid_t)*ep);
-		*ep = NULL;
+	if (raw_ep) {
+		fi_close((fid_t)raw_ep);
 	}
 
-	if (*av) {
-		fi_close((fid_t)*av);
-		*av = NULL;
+	if (raw_av) {
+		fi_close((fid_t)raw_av);
 	}
 
 	return ret;
@@ -386,13 +395,10 @@ int nccl_ofi_ofiutils_init_connection(struct fi_info *info, struct fid_domain *d
 /*
  * @brief	Release libfabric endpoint, address vector, and completion queue
  */
-void nccl_ofi_ofiutils_ep_release(struct fid_ep *ep, struct fid_av *av, int dev_id)
+void nccl_ofi_ofiutils_ep_release(FidEpPtr& ep, FidAvPtr& av, int dev_id)
 {
-	if (ep)
-		fi_close((fid_t)ep);
-
-	if (av)
-		fi_close((fid_t)av);
+	ep.reset();
+	av.reset();
 
 	NCCL_OFI_TRACE(NCCL_NET, "Libfabric endpoint and address vector of dev #%d is released", dev_id);
 }

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -2342,10 +2342,10 @@ static int init_send_comm_rails(nccl_net_ofi_rdma_send_comm_t *s_comm,
 		ep_rail = ep->rdma_endpoint_get_control_rail(rail_id);
 		remote_rdma_ep_name = &remote_control_ep_names[rail_id];
 
-		comm_rail->local_ep = ep_rail->ofi_ep;
+		comm_rail->local_ep = ep_rail->ofi_ep.get();
 
-		/* Insert remote EP address to AV */
-		ret = fi_av_insert(ep_rail->av, (void *)remote_rdma_ep_name->ep_name, 1,
+		/* Insert remote address into AV */
+		ret = fi_av_insert(ep_rail->av.get(), (void *)remote_rdma_ep_name->ep_name, 1,
 				   &comm_rail->remote_addr, 0, NULL);
 		if (OFI_UNLIKELY(ret != 1)) {
 			NCCL_OFI_WARN("Unable to insert remote address into address vector "
@@ -2360,10 +2360,10 @@ static int init_send_comm_rails(nccl_net_ofi_rdma_send_comm_t *s_comm,
 		ep_rail = ep->rdma_endpoint_get_rail(rail_id);
 		remote_rdma_ep_name = &remote_ep_names[rail_id];
 
-		comm_rail->local_ep = ep_rail->ofi_ep;
+		comm_rail->local_ep = ep_rail->ofi_ep.get();
 
 		/* Insert remote EP address to AV */
-		ret = fi_av_insert(ep_rail->av, (void *)remote_rdma_ep_name->ep_name, 1,
+		ret = fi_av_insert(ep_rail->av.get(), (void *)remote_rdma_ep_name->ep_name, 1,
 				   &comm_rail->remote_addr, 0, NULL);
 		if (OFI_UNLIKELY(ret != 1)) {
 			NCCL_OFI_WARN("Unable to insert remote address into address vector "
@@ -4385,10 +4385,10 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_domain
 		nccl_net_ofi_ep_rail_t *rail = ep->rdma_endpoint_get_control_rail(rail_id);
 		const nccl_ofi_rdma_ep_name_t *remote_ep_name = &conn_msg->control_ep_names[rail_id];
 
-		comm_rail->local_ep = rail->ofi_ep;
+		comm_rail->local_ep = rail->ofi_ep.get();
 
 		/* Insert remote EP address to AV */
-		ret = fi_av_insert(rail->av, (void *)remote_ep_name->ep_name, 1,
+		ret = fi_av_insert(rail->av.get(), (void *)remote_ep_name->ep_name, 1,
 				   &comm_rail->remote_addr, 0, NULL);
 		if (OFI_UNLIKELY(ret != 1)) {
 			NCCL_OFI_WARN("Unable to insert remote address into address vector "
@@ -4397,7 +4397,7 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_domain
 			goto error;
 		}
 
-		ret = fi_av_insert(rail->av, (void *)rail->local_ep_name, 1,
+		ret = fi_av_insert(rail->av.get(), (void *)rail->local_ep_name, 1,
 				   &comm_rail->local_addr, 0, NULL);
 		if (OFI_UNLIKELY(ret != 1)) {
 			NCCL_OFI_WARN("Unable to insert local address into address vector "
@@ -4416,10 +4416,10 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_domain
 		nccl_net_ofi_ep_rail_t *rail = ep->rdma_endpoint_get_rail(rail_id);
 		const nccl_ofi_rdma_ep_name_t *remote_ep_name = &conn_msg->ep_names[rail_id];
 
-		comm_rail->local_ep = rail->ofi_ep;
+		comm_rail->local_ep = rail->ofi_ep.get();
 
 		/* Insert remote EP address to AV */
-		ret = fi_av_insert(rail->av, (void *)remote_ep_name->ep_name, 1,
+		ret = fi_av_insert(rail->av.get(), (void *)remote_ep_name->ep_name, 1,
 				   &comm_rail->remote_addr, 0, NULL);
 		if (OFI_UNLIKELY(ret != 1)) {
 			NCCL_OFI_WARN("Unable to insert remote address into address vector "
@@ -4428,7 +4428,7 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_domain
 			goto error;
 		}
 
-		ret = fi_av_insert(rail->av, (void *)rail->local_ep_name, 1,
+		ret = fi_av_insert(rail->av.get(), (void *)rail->local_ep_name, 1,
 				   &comm_rail->local_addr, 0, NULL);
 		if (OFI_UNLIKELY(ret != 1)) {
 			NCCL_OFI_WARN("Unable to insert local address into address vector "
@@ -5149,7 +5149,7 @@ static int post_rx_buffer(nccl_net_ofi_rdma_req_t *req,
 	msg.context = rdma_req_get_ofi_context(req, ep_rail->rail_id);
 
 	req->state = NCCL_OFI_RDMA_REQ_CREATED;
-	ssize_t rc = fi_recvmsg(ep_rail->ofi_ep, &msg, flags);
+	ssize_t rc = fi_recvmsg(ep_rail->ofi_ep.get(), &msg, flags);
 	if ((rc != 0) && (rc != -FI_EAGAIN)) {
 		NCCL_OFI_WARN("Error posting rx buffer. RC: %zd, Error: %s",
 			      rc, fi_strerror(-rc));
@@ -6264,8 +6264,6 @@ void nccl_net_ofi_rdma_ep_t::ep_rail_release(nccl_net_ofi_ep_rail_t *rail, int d
 {
 	nccl_ofi_ofiutils_ep_release(rail->ofi_ep, rail->av,
 				     dev_id);
-	rail->ofi_ep = NULL;
-	rail->av = NULL;
 }
 
 
@@ -6338,8 +6336,8 @@ int nccl_net_ofi_rdma_ep_t::ep_rail_init(int dev_id, uint16_t rail_id,
 
 	ret = nccl_ofi_ofiutils_init_connection(rail_info,
 						domain_rail->domain,
-						&ep_rail->ofi_ep,
-						&ep_rail->av,
+						ep_rail->ofi_ep,
+						ep_rail->av,
 						domain_rail->cq);
 	if (tclass != FI_TC_UNSPEC) {
 		fi_freeinfo(rail_info);
@@ -6350,7 +6348,7 @@ int nccl_net_ofi_rdma_ep_t::ep_rail_init(int dev_id, uint16_t rail_id,
 
 	ep_rail->rail_id = rail_id;
 
-	ret = set_local_address(ep_rail->ofi_ep, ep_rail);
+	ret = set_local_address(ep_rail->ofi_ep.get(), ep_rail);
 	if (ret != 0) {
 		nccl_net_ofi_rdma_ep_t::ep_rail_release(ep_rail, dev_id);
 		return ret;
@@ -6514,7 +6512,7 @@ static inline int init_max_write_inline_size_if_not_initialized(nccl_net_ofi_rdm
 	if (is_max_write_inline_size_initialized == false) {
 		/* Overwrite default max_write_inline_size value if
 		 * FI_OPT_INJECT_RMA_SIZE option is available */
-		ret = get_inject_rma_size_opt(ep->rdma_endpoint_get_rail(0)->ofi_ep,
+		ret = get_inject_rma_size_opt(ep->rdma_endpoint_get_rail(0)->ofi_ep.get(),
 					      &max_write_inline_size);
 		if (ret == 0) {
 			is_max_write_inline_size_initialized = true;
@@ -6584,9 +6582,9 @@ nccl_net_ofi_rdma_ep_t::nccl_net_ofi_rdma_ep_t(nccl_net_ofi_rdma_domain_t *domai
 	this->use_long_rkeys = device->use_long_rkeys;
 
 	/* Zero-initialize the rails and control_rails vector elements */
-	this->rails = std::vector<nccl_net_ofi_ep_rail_t>(num_rails, nccl_net_ofi_ep_rail_t{});
+	this->rails.resize(num_rails);
 
-	this->control_rails = std::vector<nccl_net_ofi_ep_rail_t>(num_control_rails, nccl_net_ofi_ep_rail_t{});
+	this->control_rails.resize(num_control_rails);
 
 	ret = nccl_net_ofi_mutex_init(&this->pending_reqs_lock, NULL);
 	if (ret != 0) {

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -812,7 +812,7 @@ static int sendrecv_comm_mr_base_reg(nccl_net_ofi_comm_t *base_comm,
 	key_pool = domain->mr_rkey_pool;
 	struct fid_domain *ofi_domain;
 	ofi_domain = ep->sendrecv_endpoint_get_ofi_domain();
-	ret = sendrecv_mr_base_register(ofi_domain, ep->ofi_ep, key_pool,
+	ret = sendrecv_mr_base_register(ofi_domain, ep->ofi_ep.get(), key_pool,
 					dev_id, ckey, type, &ret_handle);
 	if (OFI_UNLIKELY(ret_handle == NULL || ret != 0)) {
 		ret_handle = NULL;
@@ -1015,12 +1015,8 @@ static int sendrecv_recv_comm_recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, v
 void nccl_net_ofi_sendrecv_ep_t::sendrecv_endpoint_abort()
 {
 	pthread_wrapper domain_lock(&this->domain->domain_lock);
-
 	int dev_id = this->domain->get_device()->dev_id;
-
 	nccl_ofi_ofiutils_ep_release(this->ofi_ep, this->av, dev_id);
-	this->ofi_ep = nullptr;
-	this->av = nullptr;
 
 	this->domain->invalidate();
 }
@@ -1325,7 +1321,7 @@ static nccl_net_ofi_sendrecv_recv_comm_t *sendrecv_recv_comm_prepare(nccl_net_of
 	int dev_id = device->dev_id;
 
 	/* Insert remote EP address to AV */
-	ret = fi_av_insert(ep->av, (void *)remote_ep_addr, 1,
+	ret = fi_av_insert(ep->av.get(), (void *)remote_ep_addr, 1,
 			   &remote_ep, 0, NULL);
 	if (OFI_UNLIKELY(ret != 1)) {
 		NCCL_OFI_WARN("Unable to insert remote address into address vector for device %d. RC: %s",
@@ -1387,7 +1383,7 @@ static nccl_net_ofi_sendrecv_recv_comm_t *sendrecv_recv_comm_prepare(nccl_net_of
 	 */
 	if (!ofi_nccl_gdr_flush_disable() && support_gdr == GDR_SUPPORTED && !cuda_flush) {
 		r_comm->flush_buff.size = NCCL_OFI_FLUSH_SIZE;
-		ret = sendrecv_recv_comm_alloc_and_reg_flush_buff(ofi_domain, ep->ofi_ep, key_pool,
+		ret = sendrecv_recv_comm_alloc_and_reg_flush_buff(ofi_domain, ep->ofi_ep.get(), key_pool,
 								  &r_comm->flush_buff, dev_id);
 		if (OFI_UNLIKELY(ret != 0)) {
 			free(r_comm);
@@ -1659,13 +1655,13 @@ int nccl_net_ofi_sendrecv_ep_t::listen(nccl_net_ofi_conn_handle_t *handle,
 
 	dev_id = device->dev_id;
 
-	local_ep_name = sendrecv_get_local_address(this->ofi_ep);
+	local_ep_name = sendrecv_get_local_address(this->ofi_ep.get());
 	if (local_ep_name == nullptr) {
 		return -EINVAL;
 	}
 
 	/* Insert local EP address to AV. This will be used to issue local read operations */
-	num_addrs = fi_av_insert(this->av, (void *)local_ep_name, 1, &local_ep_addr, 0, NULL);
+	num_addrs = fi_av_insert(this->av.get(), (void *)local_ep_name, 1, &local_ep_addr, 0, NULL);
 
 	/* Only 1 address should be inserted into the AV */
 	if (OFI_UNLIKELY(num_addrs != 1)) {
@@ -1690,7 +1686,7 @@ int nccl_net_ofi_sendrecv_ep_t::listen(nccl_net_ofi_conn_handle_t *handle,
 	l_comm->base.base.dev_id = dev_id;
 	l_comm->base.accept = sendrecv_listen_comm_accept;
 	l_comm->base.close = sendrecv_listen_comm_close;
-	l_comm->local_ep = this->ofi_ep;
+	l_comm->local_ep = this->ofi_ep.get();
 	l_comm->local_ep_addr = local_ep_addr;
 
 	l_comm->listener = domain_ptr->cm->listen();
@@ -1906,7 +1902,7 @@ static inline int sendrecv_send_comm_create(nccl_net_ofi_conn_handle_t *handle,
 	ret_s_comm->base.write = NULL;
 	ret_s_comm->base.write_inline = NULL;
 	ret_s_comm->tag = 0; /* Populate later from connect response */
-	ret_s_comm->local_ep = ep->ofi_ep;
+	ret_s_comm->local_ep = ep->ofi_ep.get();
 
 	ret_s_comm->remote_ep = 0; /* Populate later from connect response */
 	ret_s_comm->connector = nullptr;
@@ -1919,7 +1915,7 @@ static inline int sendrecv_send_comm_create(nccl_net_ofi_conn_handle_t *handle,
 
 	conn_info->ep_namelen = sizeof(conn_info->ep_name);
 
-	ret = fi_getname(&(ep->ofi_ep->fid),
+	ret = fi_getname(&(ep->ofi_ep.get()->fid),
 			 (void *)conn_info->ep_name,
 			 &conn_info->ep_namelen);
 	if (ret == -FI_ETOOSMALL) {
@@ -1998,7 +1994,7 @@ static inline int sendrecv_send_comm_process_conn_resp
 	s_comm->tag = conn_resp_msg.tag;
 
 	/* Insert remote address into AV */
-	int ret = fi_av_insert(ep->av,
+	int ret = fi_av_insert(ep->av.get(),
 			       conn_resp_msg.ep_name, 1,
 			       &s_comm->remote_ep, 0, NULL);
 	if (OFI_UNLIKELY(ret != 1)) {
@@ -2106,6 +2102,7 @@ int nccl_net_ofi_sendrecv_ep_t::cleanup_resources()
 	/* cleanup_resources should only be called once per endpoint instance */
 	assert(!this->called_cleanup_resources);
 	this->called_cleanup_resources = true;
+
 	nccl_net_ofi_sendrecv_device_t *device = nullptr;
 
 	/* Validate device */
@@ -2114,9 +2111,7 @@ int nccl_net_ofi_sendrecv_ep_t::cleanup_resources()
 		NCCL_OFI_WARN("Invalid device provided");
 		ret = -EINVAL;
 	} else {
-		nccl_ofi_ofiutils_ep_release(this->ofi_ep, this->av, device->dev_id);
-		this->ofi_ep = nullptr;
-		this->av = nullptr;		
+		nccl_ofi_ofiutils_ep_release(this->ofi_ep, this->av, device->dev_id);	
 	}
 
 	assert(ret == 0);
@@ -2157,8 +2152,8 @@ nccl_net_ofi_sendrecv_ep_t::nccl_net_ofi_sendrecv_ep_t(nccl_net_ofi_sendrecv_dom
 	struct fid_domain *ofi_domain = this->sendrecv_endpoint_get_ofi_domain();
 	ret = nccl_ofi_ofiutils_init_connection(device->info,
 						ofi_domain,
-						&this->ofi_ep,
-						&this->av,
+						this->ofi_ep,
+						this->av,
 						domain_arg->cq);
 	if (ret != 0) {
 		throw std::runtime_error("sendrecv endpoint constructor: failed to init endpoint");


### PR DESCRIPTION
Prototype using unique_ptr for Libfabric resources to help automatically clean them, even in situations where exception handling leads to skipping ther explicit clean up. Only implements the fid_ep and fid_av wrappers.

Early test for feedback.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
